### PR TITLE
feat: `zoom_content` prop for custom zoomed

### DIFF
--- a/.changeset/beige-horses-nail.md
+++ b/.changeset/beige-horses-nail.md
@@ -1,0 +1,5 @@
+---
+"svelte-medium-image-zoom": patch
+---
+
+feat: `zoom_content` prop for custom zoomed modal's content

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export interface ZoomProps {
   a11y_name_button_zoom?: string;
 
   // Your image (required).
-  children: Snippet;
+  children: Snippet<[]>;
 
   // Custom CSS class to add to the zoomed <dialog>.
   class_dialog?: string;
@@ -59,11 +59,11 @@ export interface ZoomProps {
 
   // Provide your own unzoom button icon.
   // Default: ICompress
-  icon_unzoom?: Snippet;
+  icon_unzoom?: Snippet<[]>;
 
   // Provide your own zoom button icon.
   // Default: IEnlarge
-  icon_zoom?: Snippet;
+  icon_zoom?: Snippet<[]>;
 
   // Tell the component whether or not it should be zoomed
   // Default: false
@@ -78,6 +78,14 @@ export interface ZoomProps {
   // image is inside a <p> or <button>, for example.
   // Default: 'div'
   wrap_element?: 'div' | 'span';
+
+  // Provide your own custom modal content component.
+  zoom_content?: Snippet<[{
+    img: Snippet<[]>;
+    button_unzoom: Snippet<[]>;
+    modal_state: IModalState;
+    on_unzoom: () => void;
+  }]>;
 
   // Offset in pixels the zoomed image should
   // be from the window's boundaries.

--- a/src/lib/components/zoom.svelte
+++ b/src/lib/components/zoom.svelte
@@ -32,6 +32,7 @@
     is_zoomed,
     on_zoom_change,
     wrap_element = 'div',
+    zoom_content,
     zoom_margin = 0
   }: ZoomProps = $props();
 
@@ -402,6 +403,51 @@
   }
 </script>
 
+{#snippet modal_img()}
+  <img
+    alt={img_alt}
+    src={img_src}
+    srcset={img_el?.srcset}
+    sizes={img_el?.sizes}
+    data-smiz-modal-img=""
+    id={id_modal_img}
+    style={style_modal_img_string}
+    width={style_modal_img_obj.width}
+    height={style_modal_img_obj.height}
+    bind:this={ref_modal_img}
+  />
+{/snippet}
+
+{#snippet modal_button_unzoom()}
+  <button
+    aria-label={a11y_name_button_unzoom}
+    data-smiz-btn-unzoom=""
+    onclick={handle_unzoom_btn_click}
+    type="button"
+    class={class_button_unzoom}
+  >
+    {#if icon_unzoom}
+      {@render icon_unzoom()}
+    {:else}
+      <ICompress />
+    {/if}
+  </button>
+{/snippet}
+
+{#snippet modal_content()}
+  {#if zoom_content}
+    {@render zoom_content({
+      modal_state,
+      img: modal_img,
+      on_unzoom: handle_unzoom,
+      button_unzoom: modal_button_unzoom
+    })}
+  {:else}
+    {@render modal_img()}
+    {@render modal_button_unzoom()}
+  {/if}
+{/snippet}
+
 <svelte:element this={wrap_element} aria-owns={id_modal} data-smiz="">
   <div
     data-smiz-content={data_content_state}
@@ -441,31 +487,7 @@
     >
       <div data-smiz-modal-overlay={data_overlay_state}></div>
       <div data-smiz-modal-content="" bind:this={ref_modal_content}>
-        <img
-          alt={img_alt}
-          src={img_src}
-          srcset={img_el?.srcset}
-          sizes={img_el?.sizes}
-          data-smiz-modal-img=""
-          id={id_modal_img}
-          style={style_modal_img_string}
-          width={style_modal_img_obj.width}
-          height={style_modal_img_obj.height}
-          bind:this={ref_modal_img}
-        />
-        <button
-          aria-label={a11y_name_button_unzoom}
-          data-smiz-btn-unzoom=""
-          onclick={handle_unzoom_btn_click}
-          type="button"
-          class={class_button_unzoom}
-        >
-          {#if icon_unzoom}
-            {@render icon_unzoom()}
-          {:else}
-            <ICompress />
-          {/if}
-        </button>
+        {@render modal_content()}
       </div>
     </dialog>
   {/if}

--- a/src/lib/components/zoom.svelte
+++ b/src/lib/components/zoom.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { BodyAttrs, Nullable, SupportedImage, ZoomProps } from '$lib/types.js';
+  import type { IModalState, Nullable, SupportedImage, ZoomProps } from '$lib/types.js';
+  import { default_body_attrs, IMAGE_QUERY, ModalState } from '$lib/constants.js';
   import {
     generate_id,
     get_dialog_container,
@@ -16,36 +17,6 @@
   import ICompress from './icons/i-compress.svelte';
   import IEnlarge from './icons/i-enlarge.svelte';
   import { browser } from '$app/environment';
-
-  // ==================================================
-
-  /**
-   * The selector query we use to find and track the image
-   */
-  const IMAGE_QUERY = ['img', '[role="img"]', '[data-zoom]']
-    .map((x) => `${x}:not([aria-hidden="true"])`)
-    .join(',');
-
-  /**
-   * Helps keep track of some key `<body>` attributes
-   * so we can remove and re-add them when disabling and
-   * re-enabling body scrolling
-   */
-  const default_body_attrs: BodyAttrs = {
-    overflow: '',
-    width: ''
-  };
-
-  // ==================================================
-
-  const ModalState = Object.freeze({
-    LOADED: 'LOADED',
-    LOADING: 'LOADING',
-    UNLOADED: 'UNLOADED',
-    UNLOADING: 'UNLOADING'
-  });
-
-  type IModalState = (typeof ModalState)[keyof typeof ModalState];
 
   // ==================================================
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,29 @@
+import type { BodyAttrs } from "./types.js";
+
+/**
+ * The selector query we use to find and track the image
+ */
+export const IMAGE_QUERY = ['img', '[role="img"]', '[data-zoom]']
+  .map((x) => `${x}:not([aria-hidden="true"])`)
+  .join(',');
+
+/**
+ * Helps keep track of some key `<body>` attributes
+ * so we can remove and re-add them when disabling and
+ * re-enabling body scrolling
+ */
+export const default_body_attrs: BodyAttrs = {
+  overflow: '',
+  width: ''
+};
+
+/**
+ * Track if modak image shown(loaded), showing (loading),
+ * hidden(unloaded), hiding(unloading)
+*/
+export const ModalState = Object.freeze({
+  LOADED: 'LOADED',
+  LOADING: 'LOADING',
+  UNLOADED: 'UNLOADED',
+  UNLOADING: 'UNLOADING'
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,8 +1,11 @@
 import type { Snippet } from 'svelte';
+import type { ModalState } from './constants.js';
 
 // ==================================================
 
 export type Nullable<T> = T | null;
+
+export type IModalState = (typeof ModalState)[keyof typeof ModalState];
 
 // ==================================================
 
@@ -25,5 +28,11 @@ export interface ZoomProps {
   is_zoomed?: boolean;
   on_zoom_change?: (value: boolean) => void;
   wrap_element?: 'div' | 'span';
+  zoom_content?: Snippet<[{
+    img: Nullable<HTMLImageElement>;
+    button_unzoom: Snippet;
+    moda_state: IModalState;
+    on_unzoom: () => void;
+  }]>;
   zoom_margin?: number;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,9 +29,9 @@ export interface ZoomProps {
   on_zoom_change?: (value: boolean) => void;
   wrap_element?: 'div' | 'span';
   zoom_content?: Snippet<[{
-    img: Nullable<HTMLImageElement>;
+    img: Snippet;
     button_unzoom: Snippet;
-    moda_state: IModalState;
+    modal_state: IModalState;
     on_unzoom: () => void;
   }]>;
   zoom_margin?: number;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Zoom from '$lib/index.js';
   import '$lib/styles.css';
-  import { img_that_wanaka_tree, img_douglas_bagg } from '../stories/assets/index.js';
+  import { img_that_wanaka_tree } from '../stories/assets/index.js';
 
   let is_zoomed = $state(false);
 </script>
@@ -17,15 +17,6 @@
     alt={img_that_wanaka_tree.alt}
     src={img_that_wanaka_tree.src}
     width="500"
-    decoding="async"
-    loading="lazy"
-  />
-</Zoom>
-<Zoom>
-  <img
-    alt={img_douglas_bagg.alt}
-    src={img_douglas_bagg.src}
-    height="150"
     decoding="async"
     loading="lazy"
   />

--- a/src/stories/base.css
+++ b/src/stories/base.css
@@ -101,3 +101,37 @@ img {
   outline-offset: 0.4rem;
   outline: 0.2rem solid #bd93f9;
 }
+
+.zoom-caption {
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  font-size: 1.4rem;
+  padding: 1.7rem 2.5rem;
+  opacity: 0.0001;
+  transition: opacity 0.3s;
+}
+
+.zoom-caption--loaded {
+  opacity: 1;
+}
+
+.zoom-caption--bottom {
+  inset: auto 0 0 0;
+}
+
+.zoom-caption--left {
+  max-width: 40rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.zoom-caption-cite {
+  display: block;
+  margin-top: 1.5rem;
+}
+
+.zoom-caption-link {
+  color: #fff;
+  text-underline-offset: 0.5rem;
+}

--- a/src/stories/img.stories.svelte
+++ b/src/stories/img.stories.svelte
@@ -132,7 +132,7 @@
     </Zoom>
     <p>
       The CSS class, <code>custom-zoom</code>, is sent to the component via the
-      <code>classDialog</code> string prop. Here are the styles used:
+      <code>class_dialog</code> string prop. Here are the styles used:
     </p>
     <pre>
           <code>
@@ -178,6 +178,47 @@
         />
       </Zoom>
     </dialog>
+  </main>
+</Story>
+
+<Story name="Modal Figure Caption">
+  <main aria-label="Story" class="max-w-60">
+    <h1>Modal With Figure And Caption</h1>
+    <p>
+      If you want more control over the zoom modal's content, you can pass a `zoom_content`
+      component
+    </p>
+    <Zoom>
+      {#snippet zoom_content({ img, button_unzoom, modal_state })}
+        {@render button_unzoom()}
+        <figure>
+          {@render img()}
+          <figcaption
+            class="zoom-caption zoom-caption--bottom"
+            class:zoom-caption--loaded={modal_state === 'LOADED'}
+          >
+            That Wanaka Tree, also known as the Wanaka Willow, is a willow tree located at
+            the southern end of Lake Wānaka in the Otago region of New Zealand.
+            <cite class="zoom-caption-cite">
+              Wikipedia,{' '}
+              <a
+                href="https://en.wikipedia.org/wiki/That_Wanaka_Tree"
+                class="zoom-caption-link"
+              >
+                That Wanaka Tree
+              </a>
+            </cite>
+          </figcaption>
+        </figure>
+      {/snippet}
+      <img
+        alt={img_that_wanaka_tree.alt}
+        src={img_that_wanaka_tree.src}
+        width="500"
+        decoding="async"
+        loading="lazy"
+      />
+    </Zoom>
   </main>
 </Story>
 


### PR DESCRIPTION
## Description

`zoom_content` component (snippet) prop for rendering custom zoomed modal's content.
closes #10 